### PR TITLE
[don't merge] Fix: Renamed CBS_SERVER_ADDRESS to CBS_API_ADDRESS.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
             docker run --name cbs-proxy \
               --network=host \
               -e API_SERVER_PORT=3033 \
-              -e CBS_SERVER_ADDRESS=http://localhost:4001 \
+              -e CBS_API_ADDRESS=http://localhost:4001 \
               -d adharaprojects/cbs-proxy:temp-ci-test
 
       - run:
@@ -53,7 +53,7 @@ jobs:
       - run:
           name: Test cyclos network
           command: |
-            docker exec cbs-proxy npm test -e API_SERVER_PORT=3033 -e CBS_SERVER_ADDRESS=http://localhost:4001
+            docker exec cbs-proxy npm test -e API_SERVER_PORT=3033 -e CBS_API_ADDRESS=http://localhost:4001
 
       - run:
           name: Cleanup remote docker

--- a/config/index.js
+++ b/config/index.js
@@ -6,7 +6,7 @@ const config = JSON.parse(configFile)
 
 module.exports = {
   apiServerPort: process.env.API_SERVER_PORT || config.apiServerPort,
-  cbsApiAddress: process.env.CBS_SERVER_ADDRESS || config.cbsApiAddress,
+  cbsApiAddress: process.env.CBS_API_ADDRESS || config.cbsApiAddress,
 }
 
 console.log("\nDEFAULTS LOADED:", path.resolve(configPath))


### PR DESCRIPTION
The environment variable CBS_SERVER_ADDRESS was not following convention and this PR proposes renaming it to CBS_API_ADDRESS to follow convention (the environment variable should be the same as the config string, except upper cased and words separated by _)

depends on https://github.com/AdharaProjects/cash-tokenizer-ui/issues/270